### PR TITLE
Reduced not redeemable assets opacity

### DIFF
--- a/ComoSdk/src/Controllers/Cells/AssetCell.swift
+++ b/ComoSdk/src/Controllers/Cells/AssetCell.swift
@@ -9,14 +9,17 @@ class AssetCell : UITableViewCell {
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var statusIcon: UIImageView!
+    var redeemable: Bool! = true
     
     override  func awakeFromNib() {
         assetImageView.round(4)
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-        selectedBackgroundView?.backgroundColor = selected ? UIColor(hex: "#eeeeee") : .clear
+        if redeemable {
+            super.setSelected(selected, animated: animated)
+            selectedBackgroundView?.backgroundColor = selected ? UIColor(hex: "#eeeeee") : .clear
+        }
     }
     
     func setup(asset:Como.Asset) -> Self {
@@ -29,6 +32,11 @@ class AssetCell : UITableViewCell {
             assetImageView.downloaded(from: image)
         }else{
             assetImageView.image = nil
+        }
+        
+        if !asset.redeemable {
+            redeemable = false
+            self.contentView.alpha = 0.5
         }
         
         return self


### PR DESCRIPTION
[https://linear.app/revo/issue/REV-12594/a-la-interficie-de-como-xef-pintar-gris-els-assets-notreedemable](linear)

Faig una tasca per fer que no es puguin seleccionar els assets not redeemable